### PR TITLE
Consume FIXM data from RabbitMQ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3-alpine
+
+RUN pip install --no-cache-dir pipenv
+
+WORKDIR /sos-journaler
+COPY Pipfile* ./
+RUN pipenv install
+COPY . .
+
+ENTRYPOINT ["pipenv", "run", "main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM python:3-alpine
 
+RUN apk add --no-cache g++ libc-dev
 RUN pip install --no-cache-dir pipenv
 
 WORKDIR /sos-journaler
 COPY Pipfile* ./
-RUN pipenv install
+RUN pipenv install --deploy --system --ignore-pipfile
 COPY . .
 
-ENTRYPOINT ["pipenv", "run", "main"]
+ENTRYPOINT ["python", "main.py"]

--- a/Pipfile
+++ b/Pipfile
@@ -3,10 +3,14 @@ name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
+[scripts]
+main = "python main.py"
+
 [dev-packages]
 
 [packages]
 python-dateutil = "*"
+pika = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "979a99d7a02e08635edb4b4691b68e1ad1976f9345a03041f826fee9f37081d8"
+            "sha256": "445d18567376b771885670b99aa86063341ab46c8532c2db6e54567f6cd1b82e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "pika": {
+            "hashes": [
+                "sha256:4e1a1a6585a41b2341992ec32aadb7a919d649eb82904fd8e4a4e0871c8cf3af",
+                "sha256:9fa76ba4b65034b878b2b8de90ff8660a59d925b087c5bb88f8fdbb4b64a1dbf"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.7"
+services:
+  rabbitmq:
+    image: rabbitmq:3
+  sos-journaler:
+    image: sync-or-swim/sos-journaler
+    command: >-
+      --rabbitmq-queue-name "fixm"
+      --rabbitmq-host "rabbitmq"
+    restart: unless-stopped
+  sos-swim-consumer:
+    image: sync-or-swim/sos-swim-consumer
+    command: >-
+      --swim-broker-url "tcps://ems2.swim.faa.gov:55443"
+      --swim-queue "xaviosx.gmail.com.FDPS.d10fdb36-40e9-4e7e-9881-57949c04112e.OUT"
+      --swim-connection-factory "xaviosx.gmail.com.CF"
+      --swim-vpn "FDPS"
+      --rabbitmq-host "rabbitmq"
+      --rabbitmq-queue-name "fixm"
+    environment:
+      - SWIM_USERNAME=${SWIM_USERNAME}
+      - SWIM_PASSWORD=${SWIM_PASSWORD}
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     image: sync-or-swim/sos-swim-consumer
     command: >-
       --swim-broker-url "tcps://ems2.swim.faa.gov:55443"
-      --swim-queue "xaviosx.gmail.com.FDPS.d10fdb36-40e9-4e7e-9881-57949c04112e.OUT"
-      --swim-connection-factory "xaviosx.gmail.com.CF"
+      --swim-queue ${SWIM_QUEUE}
+      --swim-connection-factory ${SWIM_CONNECTION_FACTORY}
       --swim-vpn "FDPS"
       --rabbitmq-host "rabbitmq"
       --rabbitmq-queue-name "fixm"

--- a/main.py
+++ b/main.py
@@ -1,0 +1,59 @@
+import logging
+from argparse import ArgumentParser
+from time import sleep
+import os
+
+import pika.exceptions
+
+logger = logging.getLogger("sos-journaler")
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
+
+
+def on_fixm_message(channel, method, properties, body):
+    logger.info(f"Got a FIXM message from the queue")
+
+
+def main():
+    args = get_arguments()
+
+    connection_params = pika.ConnectionParameters(host=args.rabbitmq_host)
+
+    # Connect to RabbitMQ with a retry mechanism
+    connection = None
+    while connection is None:
+        try:
+            connection = pika.BlockingConnection(connection_params)
+        except pika.exceptions.AMQPConnectionError:
+            logger.error("Connection error while connecting to RabbitMQ. "
+                         "Retrying...")
+            sleep(1)
+    logger.info("Connected to RabbitMQ")
+
+    channel = connection.channel()
+
+    # Create the queue if it doesn't already exist
+    channel.queue_declare(queue=args.rabbitmq_queue_name)
+
+    # Read FIXM data from the queue
+    channel.basic_consume(queue=args.rabbitmq_queue_name,
+                          auto_ack=True,
+                          on_message_callback=on_fixm_message)
+    channel.start_consuming()
+
+
+def get_arguments():
+    parser = ArgumentParser(
+        description="Writes FIXM data from a RabbitMQ queue to an InfluxDB "
+                    "database")
+
+    parser.add_argument("--rabbitmq-host", type=str, required=True,
+                        help="The hostname of the RabbitMQ server")
+    parser.add_argument("--rabbitmq-queue-name", type=str, required=True,
+                        help="The name of the RabbitMQ queue to read FIXM "
+                             "data from")
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This allows the journaler to consume FIXM data from RabbitMQ that was put there by the SWIM Consumer. This also incidentally introduces the main file for this project and a Dockerfile defining its runtime environment. A docker-compose.yml is created that starts this service, the SWIM Consumer, and RabbitMQ.

Resolves #18.