### PR TITLE
Switch to using environment vars for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+__pycache__/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY Pipfile* ./
 RUN pipenv install --deploy --system --ignore-pipfile
 COPY . .
 
-ENTRYPOINT ["python", "main.py"]
+CMD ["python", "main.py"]

--- a/config.py
+++ b/config.py
@@ -1,0 +1,23 @@
+import os
+import sys
+from typing import Type
+
+from log import logger
+
+
+def _from_env(name: str, type_: Type = str, default=None) -> str:
+    try:
+        return type_(os.environ[name])
+    except KeyError:
+        if default is None:
+            logger.critical(f"Environment variable {name} unset")
+            sys.exit(1)
+        else:
+            return default
+
+
+rabbitmq_host = _from_env("RABBITMQ_HOST")
+"""The hostname of the RabbitMQ server"""
+
+rabbitmq_queue_name = _from_env("RABBITMQ_QUEUE_NAME")
+"""The name of the RabbitMQ queue to read FIXM data from"""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     image: rabbitmq:3
   sos-journaler:
     image: sync-or-swim/sos-journaler
-    command: >-
-      --rabbitmq-queue-name "fixm"
-      --rabbitmq-host "rabbitmq"
+    environment:
+      - RABBITMQ_HOST=rabbitmq
+      - RABBITMQ_QUEUE_NAME=fixm
     restart: unless-stopped
   sos-swim-consumer:
     image: sync-or-swim/sos-swim-consumer

--- a/log.py
+++ b/log.py
@@ -1,0 +1,6 @@
+import logging
+import os
+
+
+logger = logging.getLogger("sos-journaler")
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))


### PR DESCRIPTION
While flags are certainly better for applications that the user will be running in their own environment, sos-journaler will probably always be run in Docker through Docker Compose. Environment variables are better supported with Docker Compose and doing so allows us to switch from using `ENTRYPOINT` to `CMD`. `CMD` is a better match for what we're trying to accomplish and seems to interact better with tooling.