### PR TITLE
Configure SWIM Consumer with environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ hs_err_pid*
 
 __pycache__/
 .env
+docker-compose.override.yml

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,43 @@
-The purpose of this repository is to pulldown, parse, and do [something] with SWIM data from the FAA.
+Introduction
+------------
 
-More to come.
+The SOS Journaler is a service that writes FIXM data to InfluxDB for querying.
+This service reads FIXM data from RabbitMQ through the
+`SOS SWIM Consumer`_. These services are managed through Docker Compose.
 
+Configuration
+-------------
+
+You must set a few environment variables before running the SOS Journaler so
+that it can access SWIM on your behalf.
+
+- ``SWIM_CONNECTION_FACTORY``: The name of the SWIM connection factory
+- ``SWIM_QUEUE``: The name of the SWIM message queue to get FIXM data from
+- ``SWIM_USERNAME``: The username to log into SWIM with
+- ``SWIM_PASSWORD``: The password to log into SWIM with
+
+You can set these environment variables using your shell, a ``.env`` file, or
+with a ``docker-compose.override.yml``.
+
+.. code-block:: yaml
+
+   version: "3.7"
+   services:
+     sos-swim-consumer:
+       environment:
+         - SWIM_CONNECTION_FACTORY=jondoe.hotmail.com.CF
+         - SWIM_QUEUE=jondoe.hotmail.com.FDPS.0a2ce3a4-50f9-4a23-bd32-a7359c028c70.OUT
+         - SWIM_USERNAME=jondoe.hotmail.com
+         - SWIM_PASSWORD=2bf22e4298934a9273ef15e
+
+Running
+-------
+
+After configuring the service, you can start it using Docker Compose. All
+Docker images are available through Docker Hub.
+
+.. code-block:: bash
+
+   docker-compose up
+
+.. _SOS SWIM Consumer: https://github.com/sync-or-swim/sos-swim-consumer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - INFLUXDB_USER=user
       - INFLUXDB_USER_PASSWORD=password
   sos-journaler:
-    image: sync-or-swim/sos-journaler
+    image: syncorswim/sos-journaler
     environment:
       - RABBITMQ_HOST=rabbitmq
       - RABBITMQ_QUEUE_NAME=fixm
@@ -19,7 +19,7 @@ services:
       - INFLUXDB_USER_PASSWORD=password
     restart: unless-stopped
   sos-swim-consumer:
-    image: sync-or-swim/sos-swim-consumer
+    image: syncorswim/sos-swim-consumer
     command: >-
       --swim-broker-url "tcps://ems2.swim.faa.gov:55443"
       --swim-queue ${SWIM_QUEUE}
@@ -28,6 +28,12 @@ services:
       --rabbitmq-host "rabbitmq"
       --rabbitmq-queue-name "fixm"
     environment:
-      - SWIM_USERNAME=${SWIM_USERNAME}
-      - SWIM_PASSWORD=${SWIM_PASSWORD}
+      - SWIM_BROKER_URL=tcps://ems2.swim.faa.gov:55443
+      - SWIM_VPN=FDPS
+      - RABBITMQ_HOST=rabbitmq
+      - RABBITMQ_QUEUE_NAME=fixm
+      - SWIM_CONNECTION_FACTORY
+      - SWIM_QUEUE
+      - SWIM_USERNAME
+      - SWIM_PASSWORD
     restart: unless-stopped


### PR DESCRIPTION
Also switched to using the image names we're using on Docker Hub and added some documentation on how to start this system.